### PR TITLE
feat: support additional files for html conversion

### DIFF
--- a/src/chromium/converters/html.converter.ts
+++ b/src/chromium/converters/html.converter.ts
@@ -44,6 +44,7 @@ export class HtmlConverter extends Converter {
      */
     async convert({
                       html,
+                      assets,
                       header,
                       footer,
                       properties,
@@ -57,6 +58,7 @@ export class HtmlConverter extends Converter {
                       failOnConsoleExceptions,
                   }: {
         html: PathLikeOrReadStream;
+        assets?: PathLikeOrReadStream[]
         header?: PathLikeOrReadStream;
         footer?: PathLikeOrReadStream;
         properties?: PageProperties;
@@ -72,6 +74,10 @@ export class HtmlConverter extends Converter {
         const data = new FormData();
 
         await ConverterUtils.addFile(data, html, "index.html");
+
+        if (assets) {
+            await Promise.all(assets.map((asset) => ConverterUtils.addFile(data, asset)))
+        }
 
         await ConverterUtils.customize(data, {
             header,

--- a/src/chromium/utils/converter.utils.ts
+++ b/src/chromium/utils/converter.utils.ts
@@ -99,7 +99,7 @@ export class ConverterUtils {
      * @param {string} name - The name to be used for the file in the FormData.
      * @returns {Promise<void>} A Promise that resolves once the file has been added.
      */
-    public static async addFile(data: FormData, file: PathLikeOrReadStream, name: string) {
+    public static async addFile(data: FormData, file: PathLikeOrReadStream, name?: string) {
         if (Buffer.isBuffer(file)) {
             data.append("files", file, name);
         } else if (file instanceof ReadStream) {


### PR DESCRIPTION
## Description
Support Additional files for HTML conversion
It is possible to send additional files which are referenced on the main html file as you can see on the [gotenberg docs](https://gotenberg.dev/docs/routes#html-file-into-pdf-route)