### PR TITLE
feat: support assets for html conversion

### DIFF
--- a/src/chromium/converters/html.converter.ts
+++ b/src/chromium/converters/html.converter.ts
@@ -44,6 +44,7 @@ export class HtmlConverter extends Converter {
      */
     async convert({
                       html,
+                      assets,
                       header,
                       footer,
                       properties,
@@ -57,6 +58,7 @@ export class HtmlConverter extends Converter {
                       failOnConsoleExceptions,
                   }: {
         html: PathLikeOrReadStream;
+        assets?: { file: PathLikeOrReadStream, name: string }[]
         header?: PathLikeOrReadStream;
         footer?: PathLikeOrReadStream;
         properties?: PageProperties;
@@ -72,6 +74,10 @@ export class HtmlConverter extends Converter {
         const data = new FormData();
 
         await ConverterUtils.addFile(data, html, "index.html");
+
+        if (assets?.length) {
+            await Promise.all(assets.map(({ file, name }) => ConverterUtils.addFile(data, file, name)))
+        }
 
         await ConverterUtils.customize(data, {
             header,

--- a/src/chromium/converters/tests/html.converter.test.ts
+++ b/src/chromium/converters/tests/html.converter.test.ts
@@ -25,7 +25,12 @@ describe("HtmlConverter", () => {
         const mockPromisesAccess = jest.spyOn(promises, "access");
         const mockFetch = fetch as jest.MockedFunction<typeof fetch>;
         const mockFormDataAppend = jest.spyOn(FormData.prototype, "append");
-        
+
+        const assets = [
+            { file: Buffer.from('asset1'), name: 'asset1' },
+            { file: Buffer.from('asset2'), name: 'asset2' }
+        ]
+
         beforeEach(() => {
             (createReadStream as jest.Mock) = jest.fn()
         });
@@ -92,6 +97,19 @@ describe("HtmlConverter", () => {
             });
         });
 
+        describe("when assets parameter is passed", () => {
+            it("should return a buffer", async () => {
+                mockFetch.mockResolvedValue(new Response("content"));
+                const buffer = await converter.convert({
+                    html: Buffer.from("data"),
+                    assets,
+                });
+
+                expect(mockFormDataAppend).toHaveBeenCalledTimes(3);
+                expect(buffer).toEqual(Buffer.from("content"));
+            });
+        });
+
         describe("when emulatedMediaType parameter is passed", () => {
             it("should return a buffer", async () => {
                 mockFetch.mockResolvedValue(new Response("content"));
@@ -110,13 +128,14 @@ describe("HtmlConverter", () => {
                 mockFetch.mockResolvedValue(new Response("content"));
                 const buffer = await converter.convert({
                     html: Buffer.from("data"),
+                    assets,
                     header: Buffer.from("header"),
                     footer: Buffer.from("footer"),
                     pdfFormat: PdfFormat.A_1a,
                     emulatedMediaType: "screen",
                     properties: {size: {width: 8.3, height: 11.7}},
                 });
-                expect(mockFormDataAppend).toHaveBeenCalledTimes(7);
+                expect(mockFormDataAppend).toHaveBeenCalledTimes(9);
                 expect(buffer).toEqual(Buffer.from("content"));
             });
         });


### PR DESCRIPTION
## Description
Support Additional files for HTML conversion
It is possible to send additional files which are referenced on `index.html` as you can see on the [gotenberg docs](https://gotenberg.dev/docs/routes#html-file-into-pdf-route)