### PR TITLE
chore: add missing option cookie to URL screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ type ScreenshotOptions = {
   failOnConsoleExceptions?: boolean; // Return a 409 Conflict response if there are exceptions in the Chromium console (default false)
   skipNetworkIdleEvent?: boolean; // Do not wait for Chromium network to be idle (default false)
   optimizeForSpeed?: boolean; // Define whether to optimize image encoding for speed, not for resulting size.
+  cookies?: Cookie[]; // Cookies to be written.
 };
 ```
 

--- a/src/chromium/converters/html.converter.ts
+++ b/src/chromium/converters/html.converter.ts
@@ -6,11 +6,11 @@ import {
     PathLikeOrReadStream,
     PdfFormat
 } from '../../common';
-import { Cookie, PageProperties } from '../interfaces/converter.types';
+import { PageProperties } from '../interfaces/converter.types';
 import { ConverterUtils } from '../utils/converter.utils';
 import { Converter } from './converter';
 import { ChromiumRoute, Chromiumly } from '../../main.config';
-import { EmulatedMediaType } from '../interfaces/common.types';
+import { EmulatedMediaType, Cookie } from '../interfaces/common.types';
 
 /**
  * Class representing an HTML converter that extends the base Converter class.

--- a/src/chromium/converters/markdown.converter.ts
+++ b/src/chromium/converters/markdown.converter.ts
@@ -6,11 +6,11 @@ import {
     PathLikeOrReadStream,
     Metadata
 } from '../../common';
-import { Cookie, PageProperties } from '../interfaces/converter.types';
+import { PageProperties } from '../interfaces/converter.types';
 import { ConverterUtils } from '../utils/converter.utils';
 import { Converter } from './converter';
 import { ChromiumRoute, Chromiumly } from '../../main.config';
-import { EmulatedMediaType } from '../interfaces/common.types';
+import { EmulatedMediaType, Cookie } from '../interfaces/common.types';
 
 /**
  * Class representing a Markdown converter that extends the base Converter class.

--- a/src/chromium/converters/url.converter.ts
+++ b/src/chromium/converters/url.converter.ts
@@ -6,11 +6,11 @@ import {
     PathLikeOrReadStream,
     Metadata
 } from '../../common';
-import { Cookie, PageProperties } from '../interfaces/converter.types';
+import { PageProperties } from '../interfaces/converter.types';
 import { ConverterUtils } from '../utils/converter.utils';
 import { Converter } from './converter';
 import { ChromiumRoute, Chromiumly } from '../../main.config';
-import { EmulatedMediaType } from '../interfaces/common.types';
+import { EmulatedMediaType, Cookie } from '../interfaces/common.types';
 
 /**
  * Class representing a URL converter that extends the base Converter class.

--- a/src/chromium/interfaces/common.types.ts
+++ b/src/chromium/interfaces/common.types.ts
@@ -2,6 +2,16 @@ import { PathLikeOrReadStream } from '../../common';
 
 export type EmulatedMediaType = 'screen' | 'print';
 
+export type Cookie = {
+    name: string;
+    value: string;
+    domain: string;
+    path?: string;
+    secure?: boolean;
+    httpOnly?: boolean;
+    sameSite?: 'Strict' | 'Lax' | 'None';
+};
+
 export type ChromiumOptions = {
     header?: PathLikeOrReadStream;
     footer?: PathLikeOrReadStream;
@@ -12,4 +22,5 @@ export type ChromiumOptions = {
     failOnHttpStatusCodes?: number[]; // Return a 409 Conflict response if the HTTP status code is in the list (default [499,599])
     failOnConsoleExceptions?: boolean; // Return a 409 Conflict response if there are exceptions in the Chromium console (default false)
     skipNetworkIdleEvent?: boolean; // Do not wait for Chromium network to be idle (default false)
+    cookies?: Cookie[]; // Cookies to be written.
 };

--- a/src/chromium/interfaces/converter.types.ts
+++ b/src/chromium/interfaces/converter.types.ts
@@ -1,5 +1,5 @@
 import { Metadata, PdfFormat } from '../../common';
-import { ChromiumOptions } from './common.types';
+import { ChromiumOptions, Cookie } from './common.types';
 
 type PageSize = {
     width: number; // Paper width, in inches (default 8.5)
@@ -23,16 +23,6 @@ export type PageProperties = {
     landscape?: boolean; // Set the paper orientation to landscape (default false)
     scale?: number; // The scale of the page rendering (default 1.0)
     nativePageRanges?: { from: number; to: number }; // Page ranges to print
-};
-
-export type Cookie = {
-    name: string;
-    value: string;
-    domain: string;
-    path?: string;
-    secure?: boolean;
-    httpOnly?: boolean;
-    sameSite?: 'Strict' | 'Lax' | 'None';
 };
 
 export type ConversionOptions = ChromiumOptions & {

--- a/src/chromium/screenshots/tests/url.screenshot.test.ts
+++ b/src/chromium/screenshots/tests/url.screenshot.test.ts
@@ -137,9 +137,16 @@ describe('URLScreenshot', () => {
                     skipNetworkIdleEvent: true,
                     failOnConsoleExceptions: true,
                     properties: { format: 'jpeg', quality: 50 },
-                    optimizeForSpeed: true
+                    optimizeForSpeed: true,
+                    cookies: [
+                        {
+                            name: 'cookie',
+                            value: 'value',
+                            domain: 'example.com'
+                        }
+                    ]
                 });
-                expect(mockFormDataAppend).toHaveBeenCalledTimes(10);
+                expect(mockFormDataAppend).toHaveBeenCalledTimes(11);
                 expect(buffer).toEqual(Buffer.from('content'));
             });
         });

--- a/src/chromium/screenshots/url.screenshot.ts
+++ b/src/chromium/screenshots/url.screenshot.ts
@@ -5,7 +5,7 @@ import { ImageProperties } from '../interfaces/screenshot.types';
 import { ScreenshotUtils } from '../utils/screenshot.utils';
 import { Screenshot } from './screenshot';
 import { ChromiumRoute, Chromiumly } from '../../main.config';
-import { EmulatedMediaType } from '../interfaces/common.types';
+import { Cookie, EmulatedMediaType } from '../interfaces/common.types';
 
 /**
  * Class representing a URL screenshot that extends the base screenshot class.
@@ -38,6 +38,7 @@ export class UrlScreenshot extends Screenshot {
      * @param {boolean} [options.failOnConsoleExceptions] - Whether to fail on console exceptions during screenshot.
      * @param {boolean} [options.skipNetworkIdleEvent] - Whether to skip network idle event.
      * @param {boolean} [options.optimizeForSpeed] - Whether to optimize for speed.
+     * @param {Cookie[]} options.cookies - Cookies to be written.
      * @returns {Promise<Buffer>} A Promise resolving to the image buffer.
      */
     async capture({
@@ -52,7 +53,8 @@ export class UrlScreenshot extends Screenshot {
         failOnHttpStatusCodes,
         failOnConsoleExceptions,
         skipNetworkIdleEvent,
-        optimizeForSpeed
+        optimizeForSpeed,
+        cookies
     }: {
         url: string;
         header?: PathLikeOrReadStream;
@@ -66,6 +68,7 @@ export class UrlScreenshot extends Screenshot {
         failOnConsoleExceptions?: boolean;
         skipNetworkIdleEvent?: boolean;
         optimizeForSpeed?: boolean;
+        cookies?: Cookie[];
     }): Promise<Buffer> {
         const _url = new URL(url);
         const data = new FormData();
@@ -83,7 +86,8 @@ export class UrlScreenshot extends Screenshot {
             failOnHttpStatusCodes,
             failOnConsoleExceptions,
             skipNetworkIdleEvent,
-            optimizeForSpeed
+            optimizeForSpeed,
+            cookies
         });
 
         return GotenbergUtils.fetch(

--- a/src/chromium/utils/screenshot.utils.ts
+++ b/src/chromium/utils/screenshot.utils.ts
@@ -123,5 +123,9 @@ export class ScreenshotUtils {
         if (options.optimizeForSpeed) {
             data.append('optimizeForSpeed', String(options.optimizeForSpeed));
         }
+
+        if (options.cookies) {
+            data.append('cookies', JSON.stringify(options.cookies));
+        }
     }
 }


### PR DESCRIPTION
Hi @cherfia 


 I was trying to use the URL screenshot feature via cookies but, although the [documentation](https://gotenberg.dev/docs/routes#screenshots-route) says that I can use the `cookie` option, the `screenshot.capture` method doesn't seem to recognize it. 
 
 
![image](https://github.com/user-attachments/assets/8afd35ee-4980-4b70-8e6a-e4a0ba3e4af5)

 
 So, I checked by testing it on my gotenberg instance and it worked. I decided to add the missing option to the documentation. Please, let me know if I can help with anything else. Thanks!


--- 


Out of this PR, it looks like the Screenshot API also accepts the `header` and `footer` options. But, there is no such option in gotenberg for Screenshots FYI

