### PR TITLE
feat: add quiet option to dotenv integration

### DIFF
--- a/src/gotenberg.ts
+++ b/src/gotenberg.ts
@@ -18,11 +18,11 @@ if (dotenv) {
     const envFile = `.env.${process.env.NODE_ENV}`;
     const envFileFallback = '.env';
 
-    const dotenvConfig = dotenv.config({ path: path.resolve(envFile) });
+    const dotenvConfig = dotenv.config({ path: path.resolve(envFile), quiet: true });
 
     // Fallback to loading the default environment file.
     if (dotenvConfig.error) {
-        dotenv.config({ path: path.resolve(envFileFallback) });
+        dotenv.config({ path: path.resolve(envFileFallback), quiet: true });
     }
 }
 


### PR DESCRIPTION
When using automated scripts with Chromiumly (especially test runners that spin up multiple new processes), the promotional dotenv messages are creating a quite a lot of noise that's also breaking the output format.