### PR TITLE
feat(pdf-engines): support downloadFrom in readMetadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,10 +622,10 @@ This method reads metadata from the provided PDF files.
 ```typescript
 import { PDFEngines } from 'chromiumly';
 
-const metadataBuffer = await PDFEngines.readMetadata([
-    'path/to/file_1.pdf',
-    'path/to/file_2.pdf'
-]);
+const metadataBuffer = await PDFEngines.readMetadata({
+    files: ['path/to/file_1.pdf'],
+    downloadFrom: [{ url: 'https://cdn.example.com/file.pdf' }] // optional: read metadata from a remote PDF
+});
 ```
 
 ##### writeMetadata

--- a/src/pdf-engines/pdf-engines.ts
+++ b/src/pdf-engines/pdf-engines.ts
@@ -253,16 +253,25 @@ export class PDFEngines {
     /**
      * Reads metadata from the provided files.
      *
-     * @param {PathLikeOrReadStream[]} files An array of PathLikes or ReadStreams to the PDF files.
+     * @param {Object} options - Options for the read metadata operation.
+     * @param {PathLikeOrReadStream[]} options.files - An array of PathLikes or ReadStreams to the PDF files.
+     * @param {DownloadFrom} [options.downloadFrom] - Download a file from a URL. It must return a Content-Disposition header with a filename parameter.
      * @returns {Promise<Buffer>} A Promise resolving to the metadata buffer.
      */
-    public static async readMetadata(
-        files: PathLikeOrReadStream[],
-        webhook?: WebhookOptions
-    ): Promise<Buffer> {
+    public static async readMetadata({
+        files,
+        downloadFrom,
+        webhook
+    }: {
+        files: PathLikeOrReadStream[];
+        downloadFrom?: DownloadFrom;
+        webhook?: WebhookOptions;
+    }): Promise<Buffer> {
         const data = new FormData();
 
         await PDFEnginesUtils.addFiles(files, data);
+
+        await PDFEnginesUtils.customize(data, { downloadFrom });
 
         const endpoint = `${Chromiumly.getGotenbergEndpoint()}/${Chromiumly.PDF_ENGINES_PATH}/${Chromiumly.PDF_ENGINE_ROUTES.readMetadata}`;
 

--- a/src/pdf-engines/tests/pdf.engine.test.ts
+++ b/src/pdf-engines/tests/pdf.engine.test.ts
@@ -180,9 +180,24 @@ describe('PDFEngines', () => {
     describe('readMetadata', () => {
         it('should return a buffer', async () => {
             mockPromisesAccess.mockResolvedValue();
-            const buffer = await PDFEngines.readMetadata(['path/to/file.pdf']);
+            const buffer = await PDFEngines.readMetadata({
+                files: ['path/to/file.pdf']
+            });
             expect(buffer).toEqual(await getResponseBuffer());
             expect(mockFormDataAppend).toHaveBeenCalledTimes(1);
+        });
+
+        it('should append downloadFrom when passed', async () => {
+            mockPromisesAccess.mockResolvedValue();
+            const buffer = await PDFEngines.readMetadata({
+                files: ['path/to/file.pdf'],
+                downloadFrom: {
+                    url: 'http://example.com',
+                    extraHttpHeaders: { 'Content-Type': 'application/json' }
+                }
+            });
+            expect(buffer).toEqual(await getResponseBuffer());
+            expect(mockFormDataAppend).toHaveBeenCalledTimes(2);
         });
     });
 


### PR DESCRIPTION
## What

`PDFEngines.readMetadata` now accepts an options object and supports the `downloadFrom` field, so metadata can be read from remotely hosted PDFs (S3, Azure Blob, internal CDN, etc.) instead of only local files/streams.

```ts
await PDFEngines.readMetadata({
  files: [],
  downloadFrom: { url: 'https://cdn.example.com/file.pdf' }
});
```

## Why

Gotenberg accepts `downloadFrom` on all `multipart/form-data` routes, but the client only wired it into `convert` and `merge`. `readMetadata` (a multipart route) had no way to point at a remote URL. This closes that gap for the read-metadata route.

Ref: https://gotenberg.dev/docs/webhook-download#download-from

## Breaking change

`readMetadata` moves from positional `(files, webhook?)` to an options object 
`readMetadata([file])` → `readMetadata({ files: [file] })`

This mirrors `convert`, `merge`, and `writeMetadata`, which already take options objects.

I went with the options-object shape for API consistency, but I'm happy to make it a non-breaking trailing positional arg (`readMetadata(files, webhook?, downloadFrom?)`) instead if you'd prefer to avoid the breaking change.